### PR TITLE
:broom: use an explicit name for the variable, at least in the first chapter

### DIFF
--- a/chapter-02/2_1_parlez_vous_francais/main.go
+++ b/chapter-02/2_1_parlez_vous_francais/main.go
@@ -11,8 +11,8 @@ func main() {
 type language string
 
 // greet says hello to the world in the specified language
-func greet(l language) string {
-	switch l {
+func greet(lang language) string {
+	switch lang {
 	case "en":
 		return "Hello world"
 	case "fr":

--- a/chapter-02/3_1_phrasebook/main.go
+++ b/chapter-02/3_1_phrasebook/main.go
@@ -23,10 +23,10 @@ var phrasebook = map[language]string{
 }
 
 // greet says hello to the world in various languages
-func greet(l language) string {
-	greeting, ok := phrasebook[l]
+func greet(lang language) string {
+	greeting, ok := phrasebook[lang]
 	if !ok {
-		return fmt.Sprintf("unsupported language: %q", l)
+		return fmt.Sprintf("unsupported language: %q", lang)
 	}
 
 	return greeting

--- a/chapter-02/4_1_flags/main.go
+++ b/chapter-02/4_1_flags/main.go
@@ -28,10 +28,10 @@ var phrasebook = map[language]string{
 }
 
 // greet says hello to the world
-func greet(l language) string {
-	greeting, ok := phrasebook[l]
+func greet(lang language) string {
+	greeting, ok := phrasebook[lang]
 	if !ok {
-		return fmt.Sprintf("unsupported language: %q", l)
+		return fmt.Sprintf("unsupported language: %q", lang)
 	}
 
 	return greeting


### PR DESCRIPTION
https://docs.google.com/document/d/1bbuBgMRSBQqPceE0tbuvKwiJdQFpHh5HPmqx78IY9k4/edit?disco=AAAAfxUnzEk
I think the point is valid - newcomers will want a variable with the same name in the code and in the test.
Plus, `l` does look like `1` a lot :(